### PR TITLE
Integration fixes with KDP

### DIFF
--- a/kolibri_sync_extras_plugin/sync/operations.py
+++ b/kolibri_sync_extras_plugin/sync/operations.py
@@ -27,8 +27,12 @@ class SyncExtrasLocalOperation(LocalOperation):
         :rtype: str[]
         """
         sync_options = OPTIONS.get("Sync", None)
+        # ensure option setting is enabled
+        if not sync_options or not sync_options.get(self.option_condition, False):
+            return []
+        # if option is enabled, check that stage is in option's stage list
         option_key = "{}_STAGES".format(self.option_condition)
-        if not sync_options or not sync_options.get(option_key, None):
+        if not sync_options.get(option_key, None):
             return []
         return sync_options.get(option_key).split(",")
 
@@ -76,7 +80,7 @@ class BackgroundJobOperation(SyncExtrasLocalOperation):
             "sync_proceed_to",
             id=context.transfer_session.id,
             target_stage=target_stage,
-            capabilities=context.capabilities,
+            capabilities=list(context.capabilities),
             start_stage=context.stage,
             extra_metadata={
                 "type": "SYNCPROCEEDTO",


### PR DESCRIPTION
- Resolves issue `Job objects need to be JSON-serializable: Object of type set is not JSON serializable`
- Fixes missing check for whether the options are enabled, not just the stages